### PR TITLE
Make sure to fetch before checking out eos tag

### DIFF
--- a/scripts/formulas/eos.sh
+++ b/scripts/formulas/eos.sh
@@ -17,6 +17,7 @@ FORMULA_TYPES=( "osx" "linux64")
 function download() {
     git clone --depth=1 ${GIT_URL} eos/
     cd eos/
+    git fetch
     git checkout ${GIT_TAG}
 }
 


### PR DESCRIPTION
Initially `bootstrap.sh` failed for me because it couldn't find the `v0.16.1` tag

```bash
Cloning into 'eos'...
remote: Enumerating objects: 160, done.
remote: Counting objects: 100% (160/160), done.
remote: Compressing objects: 100% (151/151), done.
remote: Total 160 (delta 19), reused 52 (delta 4), pack-reused 0
Receiving objects: 100% (160/160), 4.39 MiB | 1.22 MiB/s, done.
Resolving deltas: 100% (19/19), done.
error: pathspec 'v0.16.1' did not match any file(s) known to git.
```

This seems to have fixed it